### PR TITLE
Add CachedCountRegistry to cache/lazy count RDDs

### DIFF
--- a/src/main/scala/org/apache/spark/CachedCountRegistry.scala
+++ b/src/main/scala/org/apache/spark/CachedCountRegistry.scala
@@ -1,0 +1,109 @@
+package org.apache.spark
+
+import scala.collection.mutable.HashMap
+import org.apache.spark.rdd.{RDD, UnionRDD, UnionPartition}
+
+/**
+ * [[CachedCountRegistry]] provides functionality to run count and cache result for single RDD, and
+ * run single job for several RDDs with intermediate cache of those RDDs. If one of the RDDs is
+ * already counted, registry will pull cache instead of recomputing it again.
+ *
+ * Note: use 'size()' when applying to multiple RDDs, otherwise it will return list length.
+ * Usage:
+ * {{{
+ * import org.apache.spark.CachedCountRegistry
+ * import org.apache.spark.CachedCountRegistry._
+ * val rdd1 = sc.parallelize(0 until 4)
+ * val rdd2 = sc.parallelize("a" :: "b" :: Nil)
+ * rdd1.size()
+ * (rdd1 :: rdd2 :: Nil).size()
+ * }}}
+ */
+object CachedCountRegistry {
+  private val cache: HashMap[Int, Long] = new HashMap()
+
+  /** Count RDD and cache result for RDD id */
+  def cachedCount(rdd: RDD[_]): Long = {
+    cache.getOrElseUpdate(rdd.id, rdd.count)
+  }
+
+  /**
+   * Count multi RDDs as single job and cache count separately, return total count. This method
+   * will construct UnionRDD from only non-cached RDDs
+   */
+  def multiCachedCount(rdds: Seq[RDD[_]]): Long = {
+    // pull whatever cached counts we have
+    val cachedCount = rdds.map(rdd => cache.getOrElse(rdd.id, 0L)).sum
+    // if there are any non-cached RDDs, count/cache them and return total result with cached
+    val nonCachedRDDs = rdds.filter(rdd => !cache.contains(rdd.id))
+    val count = if (nonCachedRDDs.nonEmpty) {
+      val (union, partitionsMap) = makeUnionRDD(nonCachedRDDs)
+      internalMultiCachedCount(union, partitionsMap)
+    } else {
+      0L
+    }
+    count + cachedCount
+  }
+
+  /** Get current cache state */
+  def getCache(): HashMap[Int, Long] = cache.clone()
+
+  def resetCache(): Unit = cache.clear()
+
+  // == Implicit API ==
+  implicit class SingleRDDCount(rdd: RDD[_]) {
+    def size(): Long = cachedCount(rdd)
+  }
+
+  implicit class MultiRDDCount(rdds: List[RDD[_]]) {
+    def size(): Long = multiCachedCount(rdds)
+  }
+
+  /** Internal multi count cache for UnionRDD */
+  private def internalMultiCachedCount(rdd: UnionRDD[_], partitionsMap: Map[Int, Array[Int]]): Long = {
+    // each partition has unique index, so we do not expect collisions there
+    val counts = rdd.mapPartitionsWithIndex((index, iterator) => {
+      var count = 0L
+      while (iterator.hasNext) {
+        count += 1L
+        iterator.next()
+      }
+      Iterator((index, count))
+    }, preservesPartitioning = true).collectAsMap
+
+    var totalCount = 0L
+    partitionsMap.foreach { case (rddId, partitions) =>
+      var rddCount = 0L
+      partitions.foreach { index =>
+        rddCount += counts.getOrElse(index,
+          sys.error(s"Partition index $index for parent $rddId is not found in UnionRDD"))
+      }
+      // cache count and update total
+      totalCount += cache.getOrElseUpdate(rddId, rddCount)
+    }
+
+    totalCount
+  }
+
+  /** Make generic UnionRDD of type Any, return union RDD and partitions map of RDD id to index in union */
+  private def makeUnionRDD(rdds: Seq[RDD[_]]): (UnionRDD[_], Map[Int, Array[Int]]) = {
+    require(rdds.nonEmpty, "Non-empty list of RDDs required for union")
+    val sc = rdds.head.sparkContext
+    val genericRDDs = rdds.map(_.asInstanceOf[RDD[Any]])
+    val union = sc.union(genericRDDs).asInstanceOf[UnionRDD[_]]
+    // reconstruct map of RDD id and corresponding partitions
+    // map to keep order index -> RDD id connection, this assumes that RDDs are indexed exactly
+    // like in UnionRDD (which is always true for the same sequence), otherwise it will assign
+    // wrong indices
+    val indices = genericRDDs.map(_.id).zipWithIndex.map(_.swap).toMap
+    val partitions = union.partitions.map(_.asInstanceOf[UnionPartition[_]])
+    // return map of RDD index -> array of partition indices in UnionRDD
+    val partitionsMap = partitions.map { part =>
+      val rddId = indices.getOrElse(part.parentRddIndex,
+        sys.error(s"Cannot find parent RDD index ${part.parentRddIndex} in map $indices"))
+      (rddId, part.index)
+    }.groupBy(_._1).mapValues(_.map(_._2))
+
+    (union, partitionsMap)
+  }
+}

--- a/src/main/scala/org/hammerlab/magic/test/listener/Job.scala
+++ b/src/main/scala/org/hammerlab/magic/test/listener/Job.scala
@@ -1,0 +1,17 @@
+package org.hammerlab.magic.test.listener
+
+import org.hammerlab.magic.test.listener.TestSparkListener.{JobId, StageId, Time}
+
+import scala.collection.mutable
+
+case class Job(id: JobId) extends HasStatus(Running) {
+  val stages = mutable.HashMap[StageId, Stage]()
+}
+
+object Job {
+  def apply(id: JobId, start: Time): Job = {
+    val job = Job(id)
+    job.start = start
+    job
+  }
+}

--- a/src/main/scala/org/hammerlab/magic/test/listener/RDD.scala
+++ b/src/main/scala/org/hammerlab/magic/test/listener/RDD.scala
@@ -1,0 +1,5 @@
+package org.hammerlab.magic.test.listener
+
+import org.hammerlab.magic.test.listener.TestSparkListener.RddId
+
+case class RDD(id: RddId, name: String, numPartitions: Int, callSite: String, parents: Seq[RddId])

--- a/src/main/scala/org/hammerlab/magic/test/listener/Stage.scala
+++ b/src/main/scala/org/hammerlab/magic/test/listener/Stage.scala
@@ -1,0 +1,24 @@
+package org.hammerlab.magic.test.listener
+
+import org.apache.spark.scheduler.StageInfo
+import org.hammerlab.magic.test.listener.TestSparkListener.{App, JobId, RddId, StageAttemptId, StageId}
+
+import scala.collection.mutable
+
+case class Stage(app: App, id: StageId, name: String, details: String) {
+  var jobId: JobId = _
+  val attempts = mutable.HashMap[StageAttemptId, StageAttempt]()
+  val rdds = mutable.HashMap[RddId, RDD]()
+
+  def getAttemptFromInfo(stageAttemptInfo: StageInfo): StageAttempt = {
+    val stageAttemptId = stageAttemptInfo.attemptId
+
+    val stageAttempt = attempts.getOrElseUpdate(stageAttemptId, StageAttempt(app, this, stageAttemptId))
+
+    for { rddInfo <- stageAttemptInfo.rddInfos } {
+      app.handleRDDInfo(rddInfo, this)
+    }
+    stageAttempt
+  }
+}
+

--- a/src/main/scala/org/hammerlab/magic/test/listener/StageAttempt.scala
+++ b/src/main/scala/org/hammerlab/magic/test/listener/StageAttempt.scala
@@ -1,0 +1,31 @@
+package org.hammerlab.magic.test.listener
+
+import org.apache.spark.scheduler.TaskInfo
+import org.hammerlab.magic.test.listener.TestSparkListener.{App, StageAttemptId, TaskId}
+import org.hammerlab.magic.test.listener.metrics.Metrics
+
+import scala.collection.mutable
+
+case class StageAttempt(app: App, stage: Stage, id: StageAttemptId) extends HasStatus(Pending) {
+
+  def name = stage.name
+  def details = stage.details
+
+  val tasks = mutable.HashMap[TaskId, Task]()
+
+  def getTaskAttempt(taskInfo: TaskInfo): TaskAttempt = {
+    val task = tasks.getOrElseUpdate(taskInfo.index, Task(this, taskInfo.index))
+    task.getTaskAttempt(taskInfo.taskId, taskInfo.attemptNumber)
+  }
+
+  var total = Metrics()
+  var taskMaxs = Metrics()
+
+  def updateMetrics(taskDelta: Metrics, delta: Metrics) = {
+    total += delta
+    taskMaxs += taskDelta
+
+    app.updateMetrics(delta)
+  }
+}
+

--- a/src/main/scala/org/hammerlab/magic/test/listener/Status.scala
+++ b/src/main/scala/org/hammerlab/magic/test/listener/Status.scala
@@ -1,0 +1,28 @@
+package org.hammerlab.magic.test.listener
+
+import org.hammerlab.magic.test.listener.TestSparkListener.Time
+
+trait Temporal {
+  var start: Time = _
+  var end: Time = _
+}
+
+class HasStatus(var status: Status) extends Temporal
+
+trait Status
+
+case object Running extends Status
+case object Pending extends Status
+
+trait Completed extends Status {
+  def succeeded: Boolean
+}
+
+object Succeeded extends Completed {
+  override val succeeded: Boolean = true
+}
+
+case class Failed(reason: String) extends Completed {
+  override val succeeded: Boolean = false
+}
+

--- a/src/main/scala/org/hammerlab/magic/test/listener/Task.scala
+++ b/src/main/scala/org/hammerlab/magic/test/listener/Task.scala
@@ -1,0 +1,28 @@
+package org.hammerlab.magic.test.listener
+
+import org.hammerlab.magic.test.listener.TestSparkListener.{TaskAttemptId, TaskAttemptNum, TaskIndex}
+import org.hammerlab.magic.test.listener.metrics.Metrics
+
+import scala.collection.mutable
+
+case class Task(stageAttempt: StageAttempt, index: TaskIndex) {
+  def stage = stageAttempt.stage
+  def app = stage.app
+  val attempts = mutable.HashMap[TaskAttemptId, TaskAttempt]()
+
+  var maxMetrics = Metrics()
+  var totalMetrics = Metrics()
+
+  def getTaskAttempt(id: TaskAttemptId, attemptNum: TaskAttemptNum): TaskAttempt =
+    attempts.getOrElseUpdate(attemptNum, TaskAttempt(this, id, attemptNum))
+
+  def updateMetrics(newMetrics: Metrics, delta: Metrics) = {
+    totalMetrics += delta
+    val newMaxMetrics = maxMetrics max newMetrics
+    val maxDelta = newMaxMetrics - maxMetrics
+    maxMetrics = newMaxMetrics
+
+    stageAttempt.updateMetrics(maxDelta, delta)
+  }
+}
+

--- a/src/main/scala/org/hammerlab/magic/test/listener/TaskAttempt.scala
+++ b/src/main/scala/org/hammerlab/magic/test/listener/TaskAttempt.scala
@@ -1,0 +1,20 @@
+package org.hammerlab.magic.test.listener
+
+import org.apache.spark.executor.TaskMetrics
+import org.hammerlab.magic.test.listener.TestSparkListener.{TaskAttemptId, TaskAttemptNum}
+import org.hammerlab.magic.test.listener.metrics.Metrics
+
+case class TaskAttempt(task: Task, id: TaskAttemptId, attempt: TaskAttemptNum) extends HasStatus(Running) {
+  def stageAttempt = task.stageAttempt
+  def stage = stageAttempt.stage
+  def app = stage.app
+
+  var metrics: Metrics = Metrics()
+
+  def updateMetrics(taskMetrics: TaskMetrics): Unit = {
+    val newMetrics = Metrics(taskMetrics)
+    val delta = newMetrics - metrics
+    task.updateMetrics(newMetrics, delta)
+  }
+}
+

--- a/src/main/scala/org/hammerlab/magic/test/listener/TestSparkListener.scala
+++ b/src/main/scala/org/hammerlab/magic/test/listener/TestSparkListener.scala
@@ -1,0 +1,181 @@
+package org.hammerlab.magic.test.listener
+
+import org.apache.spark.scheduler.{JobSucceeded, SparkListener, SparkListenerApplicationEnd, SparkListenerApplicationStart, SparkListenerJobEnd, SparkListenerJobStart, SparkListenerStageCompleted, SparkListenerStageSubmitted, SparkListenerTaskEnd, SparkListenerTaskStart, StageInfo}
+import org.apache.spark.storage.RDDInfo
+import org.apache.spark.{Logging, Success, TaskFailedReason}
+import org.hammerlab.magic.test.listener.TestSparkListener.{AppId, AppName, JobId, RddId, StageAttemptId, StageId}
+import org.hammerlab.magic.test.listener.metrics.Metrics
+
+import scala.collection.mutable
+
+class TestSparkListener
+  extends HasStatus(Pending)
+    with SparkListener
+    with Temporal
+    with Logging {
+
+  var id: AppId = _
+  var name: AppName = _
+
+  def clear(): Unit = {
+    jobs.clear()
+    stages.clear()
+    rdds.clear()
+    metrics = Metrics()
+  }
+
+  val jobs = mutable.HashMap[JobId, Job]()
+  val stages = mutable.HashMap[StageId, Stage]()
+  val rdds = mutable.HashMap[RddId, RDD]()
+
+  override def onApplicationStart(applicationStart: SparkListenerApplicationStart): Unit = {
+    id = applicationStart.appId.getOrElse("???")
+    name = applicationStart.appName
+    start = applicationStart.time
+    status = Running
+
+    TestSparkListener.instance = this
+  }
+
+  override def onApplicationEnd(applicationEnd: SparkListenerApplicationEnd): Unit = {
+    end = applicationEnd.time
+  }
+
+  override def onJobStart(jobStart: SparkListenerJobStart): Unit = {
+    val job = jobs.getOrElseUpdate(jobStart.jobId, Job(jobStart.jobId, jobStart.time))
+    for { stageAttemptInfo <- jobStart.stageInfos } {
+      val stageAttempt = getStageAttemptFromInfo(stageAttemptInfo)
+
+      val stage = stageAttempt.stage
+      job.stages.getOrElseUpdate(stage.id, stage)
+      stage.jobId = job.id
+    }
+  }
+
+  override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = {
+    val job = jobs(jobEnd.jobId)
+    job.end = jobEnd.time
+    job.status = jobEnd.jobResult match {
+      case JobSucceeded => Succeeded
+      case status => Failed(status.toString)
+    }
+  }
+
+  def getStageAttemptFromInfo(stageAttemptInfo: StageInfo): StageAttempt = {
+    val stageId = stageAttemptInfo.stageId
+
+    val stage = stages.getOrElseUpdate(stageId, Stage(this, stageId, stageAttemptInfo.name, stageAttemptInfo.details))
+
+    stage.getAttemptFromInfo(stageAttemptInfo)
+  }
+
+  def getStageAttempt(taskStartEvent: SparkListenerTaskStart): StageAttempt =
+    getStageAttempt(taskStartEvent.stageId, taskStartEvent.stageAttemptId)
+
+  def getStageAttempt(taskEndEvent: SparkListenerTaskEnd): StageAttempt =
+    getStageAttempt(taskEndEvent.stageId, taskEndEvent.stageAttemptId)
+
+  def getStageAttempt(stageId: StageId, attemptId: StageAttemptId): StageAttempt =
+    stages(stageId).attempts(attemptId)
+
+  override def onStageSubmitted(stageSubmitted: SparkListenerStageSubmitted): Unit = {
+    val stageAttemptInfo = stageSubmitted.stageInfo
+    val stageAttempt = getStageAttemptFromInfo(stageAttemptInfo)
+    stageAttemptInfo.submissionTime match {
+      case Some(submissionTime) =>
+        stageAttempt.start = submissionTime
+        stageAttempt.status = Running
+      case None =>
+        // TODO(ryan): throw or warn?
+    }
+  }
+
+  override def onStageCompleted(stageCompleted: SparkListenerStageCompleted): Unit = {
+    val stageAttemptInfo = stageCompleted.stageInfo
+    val stageAttempt = getStageAttemptFromInfo(stageAttemptInfo)
+
+    stageAttemptInfo.submissionTime match {
+      case Some(submissionTime) =>
+        stageAttempt.start = submissionTime
+        stageAttempt.status = Running
+      case None =>
+        throw new Exception(
+          s"Missing submission time for stage attempt: $stageAttempt; $stageAttemptInfo"
+        )
+    }
+
+    stageAttemptInfo.completionTime match {
+      case Some(completionTime) =>
+        stageAttempt.end = completionTime
+        stageAttempt.status = stageAttemptInfo.failureReason match {
+          case Some(failureReason) => Failed(failureReason)
+          case None => Succeeded
+        }
+      case None =>
+        throw new Exception(
+          s"No completionTime for stage: $stageAttempt; $stageAttemptInfo, ${stageAttemptInfo.failureReason}"
+        )
+    }
+  }
+
+  def handleRDDInfo(rddInfo: RDDInfo, stage: Stage): RDD = {
+    val rddId = rddInfo.id
+    val rdd =
+      rdds.getOrElseUpdate(
+        rddId,
+        RDD(rddId, rddInfo.name, rddInfo.numPartitions, rddInfo.callSite, rddInfo.parentIds)
+      )
+    rdds.getOrElseUpdate(rddId, rdd)
+    stage.rdds.getOrElseUpdate(rddId, rdd)
+  }
+
+  override def onTaskStart(taskStart: SparkListenerTaskStart): Unit = {
+    val taskAttempt = getStageAttempt(taskStart).getTaskAttempt(taskStart.taskInfo)
+    taskAttempt.status = Running
+  }
+
+  override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
+    val stageAttempt = getStageAttempt(taskEnd)
+    val taskAttempt = stageAttempt.getTaskAttempt(taskEnd.taskInfo)
+
+    taskEnd.reason match {
+      case Success =>
+        taskAttempt.status = Succeeded
+      case reason: TaskFailedReason =>
+        taskAttempt.status = Failed(reason.toErrorString)
+    }
+
+    taskAttempt.updateMetrics(taskEnd.taskMetrics)
+  }
+
+  var metrics = Metrics()
+  def updateMetrics(delta: Metrics) = {
+    metrics += delta
+  }
+}
+
+object TestSparkListener {
+
+  var instance: TestSparkListener = _
+
+  def apply(): TestSparkListener = instance
+
+  type AppId = String
+  type App = TestSparkListener
+
+  type AppName = String
+
+  type JobId = Int
+
+  type StageId = Int
+  type StageAttemptId = Int
+
+  type TaskIndex = Int
+  type TaskId = Int
+  type TaskAttemptId = Long
+  type TaskAttemptNum = Int
+
+  type RddId = Int
+
+  type Time = Long
+}

--- a/src/main/scala/org/hammerlab/magic/test/listener/metrics/IO.scala
+++ b/src/main/scala/org/hammerlab/magic/test/listener/metrics/IO.scala
@@ -1,0 +1,43 @@
+package org.hammerlab.magic.test.listener.metrics
+
+import org.apache.spark.executor.{InputMetrics, OutputMetrics, TaskMetrics}
+import org.hammerlab.magic.test.listener.metrics.IO.{Input, Output}
+
+case class IO(bytes: Long, records: Long) {
+  def combine(o: IO, fn: (Long, Long) => Long): IO = IO(fn(bytes, o.bytes), fn(records, o.records))
+  def +(o: IO): IO = combine(o, _ + _)
+  def -(o: IO): IO = combine(o, _ - _)
+  def max(o: IO): IO = combine(o, math.max)
+  def min(o: IO): IO = combine(o, math.min)
+}
+
+object IO {
+  type Input = IO
+  type Output = IO
+
+  def apply(): IO = IO(0, 0)
+}
+
+object Input {
+  def apply(taskMetrics: TaskMetrics): Input = Input(taskMetrics.inputMetrics)
+
+  def apply(inputMetricsOpt: Option[InputMetrics]): IO =
+    inputMetricsOpt match {
+      case Some(inputMetrics) => Input(inputMetrics)
+      case None => IO(0, 0)
+    }
+
+  def apply(inputMetrics: InputMetrics): IO = IO(inputMetrics.bytesRead, inputMetrics.recordsRead)
+}
+
+object Output {
+  def apply(taskMetrics: TaskMetrics): Output = Output(taskMetrics.outputMetrics)
+
+  def apply(outputMetricsOpt: Option[OutputMetrics]): Output =
+    outputMetricsOpt match {
+      case Some(outputMetrics) => Output(outputMetrics)
+      case None => IO()
+    }
+
+  def apply(outputMetrics: OutputMetrics): Output = IO(outputMetrics.bytesWritten, outputMetrics.recordsWritten)
+}

--- a/src/main/scala/org/hammerlab/magic/test/listener/metrics/Metrics.scala
+++ b/src/main/scala/org/hammerlab/magic/test/listener/metrics/Metrics.scala
@@ -1,0 +1,59 @@
+package org.hammerlab.magic.test.listener.metrics
+
+import org.apache.spark.executor.TaskMetrics
+import org.hammerlab.magic.test.listener.metrics.IO.{Input, Output}
+
+case class Metrics(input: Input = IO(),
+                   output: Output = IO(),
+                   shuffleRead: ShuffleRead = ShuffleRead(),
+                   shuffleWrite: ShuffleWrite = ShuffleWrite()) {
+
+  def +(o: Metrics): Metrics =
+    Metrics(
+      input + o.input,
+      output + o.output,
+      shuffleRead + o.shuffleRead,
+      shuffleWrite + o.shuffleWrite
+    )
+
+  def -(o: Metrics): Metrics =
+    Metrics(
+      input - o.input,
+      output - o.output,
+      shuffleRead - o.shuffleRead,
+      shuffleWrite - o.shuffleWrite
+    )
+
+  def max(o: Metrics): Metrics =
+    Metrics(
+      input max o.input,
+      output max o.output,
+      shuffleRead max o.shuffleRead,
+      shuffleWrite max o.shuffleWrite
+    )
+
+  def min(o: Metrics): Metrics =
+    Metrics(
+      input min o.input,
+      output min o.output,
+      shuffleRead min o.shuffleRead,
+      shuffleWrite min o.shuffleWrite
+    )
+}
+
+object Metrics {
+  def apply(metrics: TaskMetrics): Metrics =
+    Metrics(
+      Input(metrics),
+      Output(metrics),
+      ShuffleRead(metrics),
+      ShuffleWrite(metrics)
+    )
+
+  //def apply(input: Input): Metrics = Metrics(input)
+  def apply(output: Output): Metrics = Metrics(output = output)
+  def apply(shuffleRead: ShuffleRead): Metrics = new Metrics(shuffleRead = shuffleRead)
+  def apply(shuffleWrite: ShuffleWrite): Metrics = new Metrics(shuffleWrite = shuffleWrite)
+
+//  def apply(): Metrics = Metrics(IO(), IO(), ShuffleRead(), ShuffleWrite())
+}

--- a/src/main/scala/org/hammerlab/magic/test/listener/metrics/ShuffleRead.scala
+++ b/src/main/scala/org/hammerlab/magic/test/listener/metrics/ShuffleRead.scala
@@ -1,0 +1,47 @@
+package org.hammerlab.magic.test.listener.metrics
+
+import org.apache.spark.executor.{ShuffleReadMetrics, TaskMetrics}
+
+case class ShuffleRead(records: Long = 0,
+                       localBytes: Long = 0,
+                       localBlocks: Long = 0,
+                       remoteBytes: Long = 0,
+                       remoteBlocks: Long = 0,
+                       fetchWaitTime: Long = 0) {
+
+  def +(o: ShuffleRead): ShuffleRead = combine(o, _ + _)
+  def -(o: ShuffleRead): ShuffleRead = combine(o, _ - _)
+  def max(o: ShuffleRead): ShuffleRead = combine(o, math.max)
+  def min(o: ShuffleRead): ShuffleRead = combine(o, math.min)
+
+  def combine(o: ShuffleRead, fn: (Long, Long) => Long): ShuffleRead =
+    ShuffleRead(
+      fn(records, o.records),
+      fn(localBytes, o.localBytes),
+      fn(localBlocks, o.localBlocks),
+      fn(remoteBytes, o.remoteBytes),
+      fn(remoteBlocks, o.remoteBlocks),
+      fn(fetchWaitTime, o.fetchWaitTime)
+    )
+}
+
+object ShuffleRead {
+
+  def apply(taskMetrics: TaskMetrics): ShuffleRead = ShuffleRead(taskMetrics.shuffleReadMetrics)
+
+  def apply(shuffleReadMetricsOpt: Option[ShuffleReadMetrics]): ShuffleRead =
+    shuffleReadMetricsOpt match {
+      case Some(shuffleReadMetrics) => ShuffleRead(shuffleReadMetrics)
+      case None => ShuffleRead()
+    }
+
+  def apply(m: ShuffleReadMetrics): ShuffleRead =
+    ShuffleRead(
+      m.recordsRead,
+      m.localBytesRead,
+      m.localBlocksFetched,
+      m.remoteBytesRead,
+      m.remoteBlocksFetched,
+      m.fetchWaitTime
+    )
+}

--- a/src/main/scala/org/hammerlab/magic/test/listener/metrics/ShuffleWrite.scala
+++ b/src/main/scala/org/hammerlab/magic/test/listener/metrics/ShuffleWrite.scala
@@ -1,0 +1,41 @@
+package org.hammerlab.magic.test.listener.metrics
+
+import org.apache.spark.executor.{ShuffleWriteMetrics, TaskMetrics}
+
+case class ShuffleWrite(records: Long = 0, bytes: Long = 0, time: Long = 0) {
+
+  def +(o: ShuffleWrite): ShuffleWrite = combine(o, _ + _)
+  def -(o: ShuffleWrite): ShuffleWrite = combine(o, _ - _)
+  def max(o: ShuffleWrite): ShuffleWrite = combine(o, math.max)
+  def min(o: ShuffleWrite): ShuffleWrite = combine(o, math.min)
+
+  def combine(o: ShuffleWrite, fn: (Long, Long) => Long): ShuffleWrite =
+    ShuffleWrite(
+      fn(records, o.records),
+      fn(bytes, o.bytes),
+      fn(time, o.time)
+    )
+
+  override def equals(o: Any): Boolean =
+    o match {
+      case s: ShuffleWrite => bytes == s.bytes && records == s.records
+      case _ => false
+    }
+}
+
+object ShuffleWrite {
+  def apply(taskMetrics: TaskMetrics): ShuffleWrite = ShuffleWrite(taskMetrics.shuffleWriteMetrics)
+
+  def apply(shuffleWriteMetricsOpt: Option[ShuffleWriteMetrics]): ShuffleWrite =
+    shuffleWriteMetricsOpt match {
+      case Some(shuffleWriteMetrics) => ShuffleWrite(shuffleWriteMetrics)
+      case None => ShuffleWrite()
+    }
+
+  def apply(m: ShuffleWriteMetrics): ShuffleWrite =
+    ShuffleWrite(
+      m.shuffleRecordsWritten,
+      m.shuffleBytesWritten,
+      m.shuffleWriteTime
+    )
+}

--- a/src/test/scala/org/hammerlab/magic/math/HyperGeometricDistributionTest.scala
+++ b/src/test/scala/org/hammerlab/magic/math/HyperGeometricDistributionTest.scala
@@ -24,7 +24,7 @@ class HyperGeometricDistributionTest extends FunSuite with Matchers {
     new Equality[ArrayBuffer[Double]] {
       override def areEqual(a: ArrayBuffer[Double], b: Any): Boolean =
         b match {
-          case s: ArrayBuffer[Double] => a.size == s.size && a.zip(s).forall(t => t._1 === t._2)
+          case s: ArrayBuffer[_] => a.size == s.size && a.zip(s).forall(t => t._1 === t._2)
           case _ => false
         }
     }

--- a/src/test/scala/org/hammerlab/magic/rdd/CachedCountRegistryTest.scala
+++ b/src/test/scala/org/hammerlab/magic/rdd/CachedCountRegistryTest.scala
@@ -1,0 +1,42 @@
+package org.hammerlab.magic.rdd
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.CachedCountRegistry
+import org.apache.spark.CachedCountRegistry._
+
+import org.hammerlab.magic.util.SparkSuite
+
+class CachedCountRegistryTest extends SparkSuite {
+  test("single rdd count") {
+    CachedCountRegistry.resetCache()
+
+    val rdd = sc.parallelize(0 until 4)
+    val count = rdd.size()
+    count should be (4)
+    CachedCountRegistry.getCache should be (Map(rdd.id -> 4))
+  }
+
+  test("multi rdd count") {
+    CachedCountRegistry.resetCache()
+
+    val rdd1 = sc.parallelize(0 until 4)
+    val rdd2 = sc.parallelize("a" :: "b" :: Nil)
+    val rdd3 = sc.parallelize(Array(true))
+
+    rdd1.size()
+    // index has shifted in previous test, so this RDD.id = 1
+    CachedCountRegistry.getCache should be (Map(rdd1.id -> 4))
+    // should apply intermediate cache for 'rdd1'
+    val count = (rdd1 :: rdd2 :: rdd3 :: Nil).size()
+    count should be (7)
+    CachedCountRegistry.getCache should be (Map(rdd1.id -> 4, rdd2.id -> 2, rdd3.id -> 1))
+  }
+
+  test("empty multi rdd count") {
+    CachedCountRegistry.resetCache()
+
+    val rdds: List[RDD[Int]] = List.empty[RDD[Int]]
+    rdds.size() should be (0)
+    CachedCountRegistry.getCache.isEmpty should be (true)
+  }
+}

--- a/src/test/scala/org/hammerlab/magic/rdd/CachedCountRegistryTest.scala
+++ b/src/test/scala/org/hammerlab/magic/rdd/CachedCountRegistryTest.scala
@@ -3,40 +3,110 @@ package org.hammerlab.magic.rdd
 import org.apache.spark.rdd.RDD
 import org.apache.spark.CachedCountRegistry
 import org.apache.spark.CachedCountRegistry._
-
+import org.hammerlab.magic.test.listener.TestSparkListener
 import org.hammerlab.magic.util.SparkSuite
+import org.scalatest.BeforeAndAfter
 
-class CachedCountRegistryTest extends SparkSuite {
-  test("single rdd count") {
+class CachedCountRegistryTest
+  extends SparkSuite
+    with BeforeAndAfter {
+
+  conf.set("spark.extraListeners", "org.hammerlab.magic.test.listener.TestSparkListener")
+
+  def listener = TestSparkListener()
+  def numStages = listener.stages.size
+
+  before {
     CachedCountRegistry.resetCache()
+    listener.clear()
+  }
 
+  test("single rdd count") {
     val rdd = sc.parallelize(0 until 4)
     val count = rdd.size()
     count should be (4)
     CachedCountRegistry.getCache should be (Map(rdd.id -> 4))
+    numStages should be(1)
   }
 
   test("multi rdd count") {
-    CachedCountRegistry.resetCache()
-
     val rdd1 = sc.parallelize(0 until 4)
     val rdd2 = sc.parallelize("a" :: "b" :: Nil)
     val rdd3 = sc.parallelize(Array(true))
 
     rdd1.size()
-    // index has shifted in previous test, so this RDD.id = 1
+
     CachedCountRegistry.getCache should be (Map(rdd1.id -> 4))
+
+    numStages should be(1)
+
     // should apply intermediate cache for 'rdd1'
     val count = (rdd1 :: rdd2 :: rdd3 :: Nil).size()
     count should be (7)
-    CachedCountRegistry.getCache should be (Map(rdd1.id -> 4, rdd2.id -> 2, rdd3.id -> 1))
+    CachedCountRegistry.getCache should be (
+      Map(
+        rdd1.id -> 4,
+        rdd2.id -> 2,
+        rdd3.id -> 1
+      )
+    )
+    numStages should be(2)
+  }
+
+  test("union rdds count") {
+    val rdd0 = sc.parallelize(0 until 8)
+    val rdd1 = sc.parallelize(0 until 4)
+    val rdd2 = sc.parallelize(0 until 2)
+    val rdd3 = sc.parallelize(0 until 1)
+
+    val rdd01 = rdd0 ++ rdd1
+    val rdd23 = rdd2 ++ rdd3
+
+    val rdd01_23 = rdd01 ++ rdd23
+
+    rdd01_23.size() should be(15)
+    CachedCountRegistry.getCache should be(
+      Map(
+        rdd0.id -> 8,
+        rdd1.id -> 4,
+        rdd2.id -> 2,
+        rdd3.id -> 1,
+        rdd01.id -> 12,
+        rdd23.id -> 3,
+        rdd01_23.id -> 15
+      )
+    )
+
+    numStages should be(1)
+
+    val rdd02 = rdd0 ++ rdd2
+    val rdd13 = rdd1 ++ rdd3
+
+    val rdd02_13 = rdd02 ++ rdd13
+
+    rdd02_13.size() should be(15)
+    CachedCountRegistry.getCache should be(
+      Map(
+        rdd0.id -> 8,
+        rdd1.id -> 4,
+        rdd2.id -> 2,
+        rdd3.id -> 1,
+        rdd01.id -> 12,
+        rdd23.id -> 3,
+        rdd01_23.id -> 15,
+        rdd02.id -> 10,
+        rdd13.id -> 5,
+        rdd02_13.id -> 15
+      )
+    )
+
+    numStages should be(1)
   }
 
   test("empty multi rdd count") {
-    CachedCountRegistry.resetCache()
-
     val rdds: List[RDD[Int]] = List.empty[RDD[Int]]
     rdds.size() should be (0)
-    CachedCountRegistry.getCache.isEmpty should be (true)
+    CachedCountRegistry.getCache().isEmpty should be (true)
+    numStages should be(0)
   }
 }

--- a/src/test/scala/org/hammerlab/magic/util/SparkSuite.scala
+++ b/src/test/scala/org/hammerlab/magic/util/SparkSuite.scala
@@ -3,7 +3,11 @@ package org.hammerlab.magic.util
 import com.holdenkarau.spark.testing.SharedSparkContext
 import org.scalatest.{FunSuite, Matchers}
 
-trait SparkSuite extends FunSuite with SharedSparkContext with Matchers {
+trait SparkSuite
+  extends FunSuite
+    with SharedSparkContext
+    with Matchers {
+
   implicit lazy val sparkContext = sc
 
   override def beforeAll(): Unit = {


### PR DESCRIPTION
This PR adds feature to cache RDD count, so next time it will not recompute count again. This also works on list of RDDs, in this case it will run count on non-cached RDDs + count from registry for cached ones.

Usage:

``` scala
import org.apache.spark.CachedCountRegistry
import org.apache.spark.CachedCountRegistry._

val rdd1 = sc.parallelize(0 until 4)
val rdd2 = sc.parallelize("a" :: "b" :: Nil)
val rdd3 = sc.parallelize(Array(true))

// count, return and store value in cache
rdd1.size()
// return total count and store count per RDD in cache, next time only non-cached RDDs 
// are computed
(rdd1 :: rdd2 :: rdd3 :: Nil).size()
```

Currently there is a gotcha, you have to use `.size()` on list of RDDs, otherwise `.size` will return length of list.
